### PR TITLE
Update Supervisely SDK to 6.73.564

### DIFF
--- a/config.json
+++ b/config.json
@@ -10,7 +10,7 @@
   ],
   "description": "Validate annotations in a project",
   "docker_image": "supervisely/base-py-sdk:6.73.564",
-  "min_instance_version": "6.12.28",
+  "instance_version": "6.15.60",
   "main_script": "src/main.py",
   "modal_template": "src/modal.html",
   "modal_template_state": {

--- a/config.json
+++ b/config.json
@@ -9,7 +9,7 @@
     "project management"
   ],
   "description": "Validate annotations in a project",
-  "docker_image": "supervisely/base-py-sdk:6.73.564",
+  "docker_image": "supervisely/base-py-sdk-hardened:6.73.564",
   "instance_version": "6.15.60",
   "main_script": "src/main.py",
   "modal_template": "src/modal.html",

--- a/config.json
+++ b/config.json
@@ -9,7 +9,7 @@
     "project management"
   ],
   "description": "Validate annotations in a project",
-  "docker_image": "supervisely/base-py-sdk:6.73.306",
+  "docker_image": "supervisely/base-py-sdk:6.73.564",
   "min_instance_version": "6.12.28",
   "main_script": "src/main.py",
   "modal_template": "src/modal.html",

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -1,1 +1,1 @@
-supervisely==6.73.145
+supervisely==6.73.564


### PR DESCRIPTION
Updates default Supervisely Docker apps to Supervisely SDK `6.73.564`.

- Updates `docker_image` tags for default Supervisely images.
- Updates Supervisely SDK references in requirements and Dockerfiles.
- Does not release applications.

Validation: generated ecosystem inventory report.
